### PR TITLE
Fix an exception on setting locale to request header

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@ spec/reports
 test/tmp
 test/version_tmp
 tmp
+tags
+*.swp
+*.un~

--- a/lib/conekta/requestor.rb
+++ b/lib/conekta/requestor.rb
@@ -15,7 +15,7 @@ module Conekta
     def request(meth, url, params=nil)
       url = self.api_url(url)
       meth = meth.downcase
-      begin      
+      begin
         conn = Faraday.new(
          :url => url,
          :ssl => { :ca_file=> File.dirname(__FILE__) + '/../ssl_data/ca_bundle.crt'}
@@ -25,7 +25,7 @@ module Conekta
         conn.headers['X-Conekta-Client-User-Agent'] = set_headers.to_json
         conn.headers['User-Agent'] = 'Conekta/v1 RubyBindings/' + Conekta::VERSION
         conn.headers['Accept'] = "application/vnd.conekta-v#{Conekta.api_version}+json"
-        conn.headers['Accept-Language'] = Conekta.locale
+        conn.headers['Accept-Language'] = Conekta.locale.to_s
         conn.headers['Authorization'] = "Basic #{ Base64.encode64("#{self.api_key}" + ':')}"
         if params
           conn.params = params

--- a/lib/conekta/version.rb
+++ b/lib/conekta/version.rb
@@ -1,3 +1,3 @@
 module Conekta
-  VERSION = '0.4.7'.freeze
+  VERSION = '0.4.8'.freeze
 end


### PR DESCRIPTION
Fix an exception on setting locale to request header, as rubyst is common to set locales with a symbol other than a string. When setting locale as string `Conekta.locale = 'es'` everything works but when `Conekta.local = :es` is set an exception happen at the point where locale is set on header, exception is masked by the begin block when assigment happen an a misleading error is shown:

> Could not connect to https://api.conekta.io
> Conekta::NoConnectionError

In the way that you are trapping errors the stack trace is lost and it is hard to debug this kind of issues.
