### PR TITLE
Fix exception handling

### DIFF
--- a/lib/conekta/error.rb
+++ b/lib/conekta/error.rb
@@ -1,5 +1,5 @@
 module Conekta
-  class Error < Exception
+  class Error < StandardError
     attr_reader :message
     attr_reader :message_to_purchaser
     attr_reader :type

--- a/lib/conekta/requestor.rb
+++ b/lib/conekta/requestor.rb
@@ -24,7 +24,7 @@ module Conekta
       begin
         connection = build_connection(url, params)
         response = connection.method(meth).call
-      rescue Exception => e
+      rescue StandardError => e
         Error.error_handler(e, "")
       end
 


### PR DESCRIPTION
Don't really want to be rescuing from `SyntaxError`, `LoadError`, and `Interrupt`. Do we?