### PR TITLE
Update ConektaObjects with the attribute "values"

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -56,3 +56,7 @@
 == 0.5.3 2015-08-13
 
 * Refactorization.
+
+== 0.5.4 2015-09-08
+
+* Update ConektaObject with the attribute 'values'.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![alt tag](https://raw.github.com/conekta/conekta-ruby/master/readme_files/cover.png)
 
-# Conekta Ruby v.0.5.3
+# Conekta Ruby v.0.5.4
 
 This is a ruby library that allows interaction with https://api.conekta.io API.
 

--- a/lib/conekta/conekta_object.rb
+++ b/lib/conekta/conekta_object.rb
@@ -5,13 +5,14 @@ module Conekta
     def initialize(id=nil)
       @values = Hash.new
       @id = id.to_s
-      self["foo"] = "bar"
     end
     def set_val(k,v)
       @values[k] = v
+      self[k] = v
     end
     def unset_key(k)
       @values.delete(k)
+      self.delete(k)
     end
     def first
       self[0]

--- a/lib/conekta/conekta_object.rb
+++ b/lib/conekta/conekta_object.rb
@@ -8,9 +8,11 @@ module Conekta
     end
     def set_val(k,v)
       @values[k] = v
+      self[k] = v
     end
     def unset_key(k)
       @values.delete(k)
+      self.delete(k)
     end
     def first
       self[0]

--- a/lib/conekta/conekta_object.rb
+++ b/lib/conekta/conekta_object.rb
@@ -5,14 +5,13 @@ module Conekta
     def initialize(id=nil)
       @values = Hash.new
       @id = id.to_s
+      self["foo"] = "bar"
     end
     def set_val(k,v)
       @values[k] = v
-      self[k] = v
     end
     def unset_key(k)
       @values.delete(k)
-      self.delete(k)
     end
     def first
       self[0]

--- a/lib/conekta/version.rb
+++ b/lib/conekta/version.rb
@@ -1,3 +1,3 @@
 module Conekta
-  VERSION = '0.5.3'.freeze
+  VERSION = '0.5.4'.freeze
 end


### PR DESCRIPTION
ConektaObject was not being updated. When running pry, objects returned empty hashes instead of the real content of the object (values). IRB did not have this issue.