### PR TITLE
test submodel creation. fix create_fiscal_entity

### DIFF
--- a/lib/conekta/customer.rb
+++ b/lib/conekta/customer.rb
@@ -42,5 +42,8 @@ module Conekta
     def create_fiscal_entity(params)
       self.create_member('fiscal_entities', params)
     end
+    def create_shipping_contact(params)
+      self.create_member('shipping_contacts', params)
+    end
   end
 end

--- a/lib/conekta/customer.rb
+++ b/lib/conekta/customer.rb
@@ -7,10 +7,12 @@ module Conekta
     include Conekta::Operations::Update
     include Conekta::Operations::CustomAction
     include Conekta::Operations::CreateMember
+
     def load_from(response=nil)
       if response
         super
       end
+
       customer  =  self
       submodels = if Conekta.api_version == "1.1.0"
                     [:fiscal_entities, :sources, :shipping_contacts]
@@ -22,26 +24,33 @@ module Conekta
         self.send(submodel).each do |k,v|
           if !v.respond_to? :deleted or !v.deleted
             v.create_attr('customer', customer)
+
             self.send(submodel).set_val(k,v)
           end
         end
       end
+
       if self.respond_to? :subscription and self.subscription
          self.subscription.create_attr('customer', customer)
       end
     end
+
     def create_card(params)
       self.create_member('cards', params)
     end
+
     def create_source(params)
       self.create_member('sources', params)
     end
+
     def create_subscription(params)
       self.create_member('subscription', params)
     end
+
     def create_fiscal_entity(params)
       self.create_member('fiscal_entities', params)
     end
+
     def create_shipping_contact(params)
       self.create_member('shipping_contacts', params)
     end

--- a/lib/conekta/order.rb
+++ b/lib/conekta/order.rb
@@ -43,11 +43,11 @@ module Conekta
     end
 
     def create_discount_line(params)
-      self.create_memeber('discount_lines', params)
+      self.create_member('discount_lines', params)
     end
 
     def create_fiscal_entity(params)
-      self.create_member('fiscal_entity', params)
+      self.update(fiscal_entity: params).fiscal_entity
     end
   end
 end

--- a/spec/conekta/customer_spec.rb
+++ b/spec/conekta/customer_spec.rb
@@ -45,6 +45,56 @@ describe Conekta::Customer do
       customer.update({name: 'Logan', email: 'logan@x-men.org'})
       expect(customer.name).to eq('Logan')
     end
+
+    context "creating submodels" do
+      include_context "API 1.1.0"
+      include_context "customer"
+
+      let(:customer) { Conekta::Customer.create(customer_data) }
+
+      let(:classes) do
+        {
+          shipping_contact: "ShippingContact",
+          source:           "Source"
+        }
+      end
+
+      let(:source_params) do
+        {
+          type:     "card",
+          token_id: "tok_test_visa_4242"
+        }
+      end
+
+      let(:shipping_contact_params) do
+        {
+          email: "rogue@xmen.org",
+          address: {
+            street1: "250 Alexis St",
+            city: "Red Deer",
+            state: "Alberta",
+            country: "CA",
+            zip: "T4N 0B8",
+          }
+        }
+      end
+
+      let(:submodel_params) do
+        {
+          source:           source_params,
+          shipping_contact: shipping_contact_params
+        }
+      end
+
+      [:source, :shipping_contact].each do |submodel|
+        it "successfully creates #{submodel} for customer" do
+          new_submodel =
+            customer.send("create_#{submodel}", submodel_params[submodel])
+
+          expect(new_submodel.class.to_s).to eq("Conekta::#{classes[submodel]}")
+        end
+      end
+    end
   end
 
   context "deleting customers" do

--- a/spec/conekta/order_spec.rb
+++ b/spec/conekta/order_spec.rb
@@ -121,6 +121,91 @@ describe Conekta::Order do
       expect_to_raise_error_list(Conekta::ErrorList, nil, Conekta::ParameterValidationError) \
             { order.update(charges: charges) }
     end
+
+    context "creating submodels" do
+      let(:classes) do
+        {
+          line_item: "LineItem",
+          tax_line:  "TaxLine",
+          shipping_line: "ShippingLine",
+          discount_line: "DiscountLine",
+          fiscal_entity: "FiscalEntity"
+        }
+      end
+
+      let(:line_item_params) do
+        {
+          name: "Box of Cohiba S1s",
+          description: "Imported From Mex.",
+          unit_price: 35000,
+          quantity: 1,
+          tags: ["food", "mexican food"],
+          type: "physical"
+        }
+      end
+
+      let(:tax_line_params) do
+        {
+          description: "IVA",
+          amount:      600
+        }
+      end
+
+      let(:shipping_line_params) do
+        {
+          description:     "Otro Shipping",
+          amount:          40,
+          tracking_number: "TRACK124",
+          carrier:         "USPS",
+          method:          "Train",
+        }
+      end
+
+      let(:fiscal_entity_params) do
+        {
+          tax_id: "AMGH851205MN2",
+          company_name: "Nike SA de CV",
+          address: {
+            street1: "250 Alexis St",
+            internal_number: 20,
+            external_number: 02,
+            city: "Red Deer",
+            state: "Alberta",
+            country: "CA",
+            zip: "T4N 0B8"
+          }
+        }
+      end
+
+      let(:discount_line_params) do
+        {
+          description: "Cupon de descuento",
+          kind:        "loyalty",
+          amount:      10
+        }
+      end
+
+      let(:submodel_params) do
+        {
+          line_item: line_item_params,
+          tax_line: tax_line_params,
+          shipping_line: shipping_line_params,
+          discount_line: discount_line_params,
+          fiscal_entity: fiscal_entity_params
+        }
+      end
+
+      [:line_item, :tax_line, :shipping_line, :discount_line, :fiscal_entity].
+        each do |submodel|
+        it "successfully creates #{submodel} for order" do
+          new_submodel =
+            order.send("create_#{submodel}", submodel_params[submodel])
+
+          expect(new_submodel.class.to_s).to eq("Conekta::#{classes[submodel]}")
+        end
+      end
+
+    end
   end
 
   context "get" do


### PR DESCRIPTION
- No hay endpoint para fiscal entity dentro de order. La única forma de crearlo es mandarlo como parámetros de order.
- Test para creación de submodelos