### PR TITLE
Shipping contact with List

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,5 +4,6 @@ gem 'rspec'
 gem 'faraday'
 gem 'json'
 gem 'i18n'
+
 # Specify your gem's dependencies in conekta.gemspec
 gemspec

--- a/lib/conekta/conekta_object.rb
+++ b/lib/conekta/conekta_object.rb
@@ -1,23 +1,29 @@
 module Conekta
   class ConektaObject < Hash
     attr_reader :values
+
     def initialize
       @values = Hash.new
     end
+
     def set_val(k,v)
       @values[k] = v
       self[k] = v
     end
+
     def unset_key(k)
       @values.delete(k)
       self.delete(k)
     end
+
     def first
       self[0]
     end
+
     def last
       self[self.count - 1]
     end
+
     def load_from(response)
       if response.instance_of?(Array)
         response.each_with_index do |v, i|
@@ -30,9 +36,11 @@ module Conekta
         end
       end
     end
+
     def to_s
       @values.inspect
     end
+
     def inspect
       if self.respond_to? :each
         if self.class.class_name != "ConektaObject"
@@ -44,12 +52,15 @@ module Conekta
         super
       end
     end
+
     def self.class_name
       self.name.split('::')[-1]
     end
+
     def class_name
       self.class.name.split('::')[-1]
     end
+
     def create_attr(k,v)
       # Conflict with Resource Class Url
       k = "_#{k}" if k.to_s == "method"
@@ -65,7 +76,9 @@ module Conekta
         }
       end
     end
+
     protected
+
     def to_hash
       hash = Hash.new
       self.values.each do |k,v|
@@ -73,13 +86,16 @@ module Conekta
       end
       hash
     end
-    def create_method( name, &block )
-        self.class.send( :define_method, name, &block )
+
+    def create_method(name, &block)
+        self.class.send(:define_method, name, &block)
     end
+
     def load_from_enumerable(k,v)
       if v.respond_to? :each and !v.instance_of?(ConektaObject)
         v = Conekta::Util.convert_to_conekta_object(k,v)
       end
+
       if self.instance_of?(ConektaObject)
         self[k] = v
       else
@@ -87,5 +103,6 @@ module Conekta
       end
       self.set_val(k,v)
     end
+
   end
 end

--- a/lib/conekta/customer.rb
+++ b/lib/conekta/customer.rb
@@ -13,19 +13,21 @@ module Conekta
         super
       end
 
-      customer  =  self
-      submodels = if Conekta.api_version == "1.1.0"
-                    [:fiscal_entities, :sources, :shipping_contacts]
-                  else
-                    [:cards]
-                  end
+      customer = self
 
-      submodels.each do |submodel|
-        self.send(submodel).each do |k,v|
-          if !v.respond_to? :deleted or !v.deleted
-            v.create_attr('customer', customer)
+      if Conekta.api_version == "1.1.0"
+        submodels = [:fiscal_entities, :sources, :shipping_contacts]
+        create_submodels_lists(customer, submodels)
+      else
+        submodels = [:cards]
 
-            self.send(submodel).set_val(k,v)
+        submodels.each do |submodel|
+          self.send(submodel).each do |k,v|
+            if !v.respond_to? :deleted or !v.deleted
+              v.create_attr('customer', customer)
+
+              self.send(submodel).set_val(k,v)
+            end
           end
         end
       end
@@ -53,6 +55,16 @@ module Conekta
 
     def create_shipping_contact(params)
       self.create_member('shipping_contacts', params)
+    end
+
+    def create_submodels_lists(customer, submodels)
+      submodels.each do |submodel|
+        self.send(submodel).each do |k, v|
+          v.create_attr('customer', customer)
+
+          self.send(submodel).set_val(k,v)
+        end
+      end
     end
   end
 end

--- a/lib/conekta/list.rb
+++ b/lib/conekta/list.rb
@@ -8,6 +8,17 @@ module Conekta
       @params = (params || {})
     end
 
+    def add_element(element)
+      element =
+        Conekta::Util.convert_to_conekta_object(element['object'], element)
+
+      self[@total]        = element
+      self.values[@total] = element
+      @total              = @total + 1
+
+      self
+    end
+
     def next(options={})
       if self.size > 0
         if !@ending_before.nil?
@@ -42,6 +53,7 @@ module Conekta
     end
 
     private
+
     def move_cursor(limit)
       @params["limit"] = limit if !limit.nil? && !limit.to_s.empty?
       _url = Util.types[@elements_type.downcase]._url

--- a/lib/conekta/order.rb
+++ b/lib/conekta/order.rb
@@ -12,22 +12,13 @@ module Conekta
       end
 
       order     = self
-      submodels = [:line_items, :tax_lines, :shipping_lines, :discount_lines]
-
-      submodels.each do |submodel|
-        self.send(submodel).each do |k,v|
-          if !v.respond_to?(:deleted) || !v.deleted
-            v.create_attr('order', order)
-
-            self.send(submodel).set_val(k,v)
-          end
-        end
-      end
+      submodels = [:line_items, :tax_lines, :shipping_lines, :discount_lines,
+                   :returns, :charges]
+      create_submodels_lists(order, submodels)
 
       if self.respond_to?(:fiscal_entity) && self.fiscal_entity
         self.fiscal_entity.create_attr('order', order)
       end
-
     end
 
     def create_line_item(params)
@@ -46,12 +37,26 @@ module Conekta
       self.create_member('discount_lines', params)
     end
 
+    def create_charge(params)
+      self.create_member('charges', params)
+    end
+
     def create_fiscal_entity(params)
       self.update(fiscal_entity: params).fiscal_entity
     end
 
-    def create_charge(params)
-      self.create_member('charges', params)
+    def create_shipping_contact(params)
+      self.update(shipping_contact: params).shipping_contact
+    end
+
+    def create_submodels_lists(order, submodels)
+      submodels.each do |submodel|
+        self.send(submodel).each do |k, v|
+          v.create_attr('order', order)
+
+          self.send(submodel).set_val(k,v)
+        end
+      end
     end
   end
 end

--- a/lib/conekta/util.rb
+++ b/lib/conekta/util.rb
@@ -29,15 +29,22 @@ module Conekta
         'shipping_line' => ShippingLine,
         'discount_line' => DiscountLine,
         'fiscal_entity' => FiscalEntity,
-        'shipping_contact' => ShippingContact
+        'shipping_contact' => ShippingContact,
+        'list'             => List
       }
     end
 
     def self.convert_to_conekta_object(name,resp)
       if resp.kind_of?(Hash)
         if resp.has_key?('object') and types[resp['object']]
-          instance = types[resp['object']].new()
+          if resp['object'] == "list"
+            instance = types[resp['object']].new(name, resp)
+          else
+            instance = types[resp['object']].new()
+          end
+
           instance.load_from(resp)
+
           return instance
         elsif name.instance_of? String
           name = "event_data" if camelize(name) == "Data"

--- a/spec/conekta/customer_spec.rb
+++ b/spec/conekta/customer_spec.rb
@@ -52,13 +52,6 @@ describe Conekta::Customer do
 
       let(:customer) { Conekta::Customer.create(customer_data) }
 
-      let(:classes) do
-        {
-          shipping_contact: "ShippingContact",
-          source:           "Source"
-        }
-      end
-
       let(:source_params) do
         {
           type:     "card",
@@ -69,6 +62,8 @@ describe Conekta::Customer do
       let(:shipping_contact_params) do
         {
           email: "rogue@xmen.org",
+          phone: "+5213353319758",
+          receiver: "Test Conekta",
           address: {
             street1: "250 Alexis St",
             city: "Red Deer",
@@ -79,20 +74,19 @@ describe Conekta::Customer do
         }
       end
 
-      let(:submodel_params) do
-        {
-          source:           source_params,
-          shipping_contact: shipping_contact_params
-        }
+      it "successfully creates source for customer" do
+        source = customer.create_source(source_params)
+
+        expect(source.class.to_s).to eq("Conekta::Source")
+        expect(customer.sources.class.to_s).to eq("Conekta::List")
       end
 
-      [:source, :shipping_contact].each do |submodel|
-        it "successfully creates #{submodel} for customer" do
-          new_submodel =
-            customer.send("create_#{submodel}", submodel_params[submodel])
+      it "successfully creates shipping contact for customer" do
+        shipping_contact =
+          customer.create_shipping_contact(shipping_contact_params)
 
-          expect(new_submodel.class.to_s).to eq("Conekta::#{classes[submodel]}")
-        end
+        expect(shipping_contact.class.to_s).to eq("Conekta::ShippingContact")
+        expect(customer.shipping_contacts.class.to_s).to eq("Conekta::List")
       end
     end
   end

--- a/spec/conekta/discount_line_spec.rb
+++ b/spec/conekta/discount_line_spec.rb
@@ -26,7 +26,7 @@ describe Conekta::DiscountLine do
   let(:discount_line) { order.discount_lines.first }
 
   context "deleting discount lines" do
-    xit "successful discount line delete" do
+    it "successful discount line delete" do
       discount_line.delete
 
       expect(discount_line.deleted).to eq(true)
@@ -34,7 +34,7 @@ describe Conekta::DiscountLine do
   end
 
   context "updating discount lines" do
-    xit "successful discount line update" do
+    it "successful discount line update" do
       discount_line.update(amount: 11)
 
       expect(discount_line.amount).to eq(11)

--- a/spec/conekta/line_item_spec.rb
+++ b/spec/conekta/line_item_spec.rb
@@ -31,7 +31,7 @@ describe Conekta::LineItem do
   let(:line_item) { order.line_items.first }
 
   context "deleting line items" do
-    xit "successful line item delete" do
+    it "successful line item delete" do
       line_item.delete
 
       expect(line_item.deleted).to eq(true)
@@ -39,7 +39,7 @@ describe Conekta::LineItem do
   end
 
   context "updating line items" do
-    xit "successful line item update" do
+    it "successful line item update" do
       line_item.update(unit_price: 1000)
 
       expect(line_item.unit_price).to eq(1000)

--- a/spec/conekta/order_spec.rb
+++ b/spec/conekta/order_spec.rb
@@ -130,16 +130,6 @@ describe Conekta::Order do
   end
 
   context "creating submodels" do
-    let(:classes) do
-      {
-        line_item: "LineItem",
-        tax_line:  "TaxLine",
-        shipping_line: "ShippingLine",
-        discount_line: "DiscountLine",
-        fiscal_entity: "FiscalEntity"
-      }
-    end
-
     let(:line_item_params) do
       {
         name: "Box of Cohiba S1s",
@@ -202,6 +192,28 @@ describe Conekta::Order do
       }
     end
 
+    let(:shipping_contact_params) do
+      {
+        id: "1jap4jmcjnwh34",
+        email: "thomas.logan@xmen.org",
+        phone: "+5213353319758",
+        receiver: "Marvin Fuller",
+        between_streets: {
+          street1: "Ackerman Crescent",
+        },
+        address: {
+          street1: "250 Alexis St",
+          city: "Red Deer",
+          state: "Alberta",
+          country: "MX",
+          zip: "78219",
+          residential: true
+        }
+      }
+    end
+
+    let(:order) { Conekta::Order.create(order_data) }
+
     it "successfully creates charge for order" do
       other_params = {
         currency: 'mxn',
@@ -212,45 +224,51 @@ describe Conekta::Order do
         }
       }
 
-      order = Conekta::Order.create(order_data.merge(other_params))
-      new_submodel = order.create_charge charge_params
+      order  = Conekta::Order.create(order_data.merge(other_params))
+      charge = order.create_charge(charge_params)
 
-      expect(new_submodel.class.to_s).to eq("Conekta::Charge")
+      expect(charge.class.to_s).to eq("Conekta::Charge")
+      expect(order.charges.class.to_s).to eq("Conekta::List")
     end
 
     it "successfully creates line item for order" do
-      order = Conekta::Order.create order_data
-      new_submodel = order.create_line_item line_item_params
+      line_item = order.create_line_item(line_item_params)
 
-      expect(new_submodel.class.to_s).to eq("Conekta::LineItem")
+      expect(line_item.class.to_s).to eq("Conekta::LineItem")
+      expect(order.line_items.class.to_s).to eq("Conekta::List")
     end
 
     it "successfully creates tax line for order" do
-      order = Conekta::Order.create order_data
-      new_submodel = order.create_tax_line tax_line_params
+      tax_line = order.create_tax_line(tax_line_params)
 
-      expect(new_submodel.class.to_s).to eq("Conekta::TaxLine")
+      expect(tax_line.class.to_s).to eq("Conekta::TaxLine")
+      expect(order.tax_lines.class.to_s).to eq("Conekta::List")
     end
 
     it "successfully creates shipping line for order" do
-      order = Conekta::Order.create order_data
-      new_submodel = order.create_shipping_line shipping_line_params
+      shipping_line = order.create_shipping_line(shipping_line_params)
 
-      expect(new_submodel.class.to_s).to eq("Conekta::ShippingLine")
+      expect(shipping_line.class.to_s).to eq("Conekta::ShippingLine")
+      expect(order.shipping_lines.class.to_s).to eq("Conekta::List")
     end
 
     it "successfully creates discount line for order" do
-      order = Conekta::Order.create order_data
-      new_submodel = order.create_discount_line discount_line_params
+      discount_line = order.create_discount_line(discount_line_params)
 
-      expect(new_submodel.class.to_s).to eq("Conekta::DiscountLine")
+      expect(discount_line.class.to_s).to eq("Conekta::DiscountLine")
+      expect(order.discount_lines.class.to_s).to eq("Conekta::List")
     end
 
     it "successfully creates fiscal entity for order" do
-      order = Conekta::Order.create order_data
-      new_submodel = order.create_fiscal_entity fiscal_entity_params
+      fiscal_entity = order.create_fiscal_entity(fiscal_entity_params)
 
-      expect(new_submodel.class.to_s).to eq("Conekta::FiscalEntity")
+      expect(fiscal_entity.class.to_s).to eq("Conekta::FiscalEntity")
+    end
+
+    it "successfully create shipping contact for order" do
+      shipping_contact = order.create_shipping_contact(shipping_contact_params)
+
+      expect(shipping_contact.class.to_s).to eq("Conekta::ShippingContact")
     end
   end
 

--- a/spec/conekta/order_spec.rb
+++ b/spec/conekta/order_spec.rb
@@ -239,10 +239,12 @@ describe Conekta::Order do
     end
 
     it "successfully creates tax line for order" do
-      tax_line = order.create_tax_line(tax_line_params)
+      tax_line     = order.create_tax_line(tax_line_params)
+      new_tax_line = order.create_tax_line(description: "ISR", amount: 2)
 
       expect(tax_line.class.to_s).to eq("Conekta::TaxLine")
       expect(order.tax_lines.class.to_s).to eq("Conekta::List")
+      expect(order.tax_lines.total).to eq(2)
     end
 
     it "successfully creates shipping line for order" do

--- a/spec/conekta/shipping_contact_spec.rb
+++ b/spec/conekta/shipping_contact_spec.rb
@@ -6,16 +6,20 @@ describe Conekta::ShippingContact do
 
   let(:shipping_contacts) do
     [{
-      email: "thomas.logan@xmen.org",
-      address: {
-        street1: "250 Alexis St",
-        city: "Red Deer",
-        state: "Alberta",
-        country: "CA",
-        zip: "T4N 0B8",
-      }
+       receiver: "John Williams",
+       phone: "+5213353319758",
+       email: "thomas.logan@xmen.org",
+       address: {
+         street1: "250 Alexis St",
+         city: "Red Deer",
+         state: "Alberta",
+         country: "CA",
+         zip: "T4N 0B8",
+       }
      },
      {
+       receiver: "John Williams",
+       phone: "+5213353319758",
        email: "rogue@xmen.org",
        address: {
          street1: "250 Alexis St",


### PR DESCRIPTION
- Las listas se estaban creando erróneamente
- Se agregó el método `add_element` para las listas, para cuando se crea un submodelo para orden y customer.