### PR TITLE
Inherit exceptions from standard error

### DIFF
--- a/lib/conekta/error.rb
+++ b/lib/conekta/error.rb
@@ -1,5 +1,5 @@
 module Conekta
-  class Error < Exception
+  class Error < StandardError
     attr_reader :message, :message_to_purchaser, :param, :code
     # NEW FIELDS
     attr_reader :validation_error, :custom_message

--- a/lib/conekta/error_list.rb
+++ b/lib/conekta/error_list.rb
@@ -1,5 +1,5 @@
 module Conekta
-  class ErrorList < Exception
+  class ErrorList < StandardError
     attr_accessor :details
 
     def initialize

--- a/lib/conekta/requestor.rb
+++ b/lib/conekta/requestor.rb
@@ -26,7 +26,7 @@ module Conekta
         response = connection.method(meth).call do |req|
           (if meth == :get then req.params = params else req.body = params.to_json end) if params
         end
-      rescue Exception => e
+      rescue StandardError => e
         if Conekta.api_version == "2.0.0"
           json_response = {"details" => []}
         else

--- a/spec/conekta/2.0.0/order_spec.rb
+++ b/spec/conekta/2.0.0/order_spec.rb
@@ -276,7 +276,7 @@ describe Conekta::Order do
                                     merge(line_items: line_items))
       begin
 				order.refund(order_refund)
-      rescue Exception => e
+      rescue StandardError => e
 				puts e.details.map{|d| d.message}
       end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -20,5 +20,6 @@ def expect_to_raise_error_list(klass, message, subklass, &block)
     expect(exception.details).to be_instance_of(Array)
     expect(exception.details).not_to be_empty
     expect(exception.details.first).to be_instance_of(subklass)
+    expect(exception.class).to be < StandardError
   end
 end


### PR DESCRIPTION
# Description

Makes exceptions inherit from `StandardError`. Inheriting from Exception breaks the expected behavior of rescue:

```Ruby
begin
  raise Conekta::Error
rescue => error # this rescues StandardError, not Exception
  puts 'I never got rescued! D:'
end
```

Closes #66 