### PR TITLE
Fix: Change encode function

### DIFF
--- a/lib/conekta/requestor.rb
+++ b/lib/conekta/requestor.rb
@@ -60,7 +60,7 @@ module Conekta
       connection.headers['User-Agent'] = 'Conekta/v1 RubyBindings/' + Conekta::VERSION
       connection.headers['Accept'] = "application/vnd.conekta-v#{Conekta.api_version}+json"
       connection.headers['Accept-Language'] = Conekta.locale.to_s
-      connection.headers['Authorization'] = "Basic #{ Base64.encode64("#{self.api_key}" + ':')}"
+      connection.headers['Authorization'] = "Basic #{ Base64.strict_encode64("#{self.api_key}" + ':')}"
       return connection
     end
 


### PR DESCRIPTION
This change comes up from an issue of an user  that does not sanitize their api_key.
his api_key format was in this way:
```
Conekta.api_key = "key_eYvWV7gSDkNYXsmr\n" he was append a line fee in the end
```
so this cause an error in the  authentication header:
```
"Baic a2V5X0xTU0RyaHg5TVNMcFpUeVZLeENkb2RnOg==\n"
```

To solve that problem he suggest strict_encode64 instead encode64

strict_encode64:
Returns the Base64-encoded version of bin. This method complies with RFC 4648. No line feeds are added.

[issue](https://github.com/conekta/conekta-ruby/issues/71)
[strict_encode64](https://ruby-doc.org/stdlib-2.1.3/libdoc/base64/rdoc/Base64.html#method-i-strict_encode64)