### PR TITLE
payment sources are filtered from API 

### DIFF
--- a/lib/conekta/conekta_object.rb
+++ b/lib/conekta/conekta_object.rb
@@ -7,6 +7,7 @@ module Conekta
     end
 
     def set_val(k,v)
+      @values ||= {}
       @values[k] = v
       self[k] = v
     end

--- a/lib/conekta/conekta_object.rb
+++ b/lib/conekta/conekta_object.rb
@@ -21,7 +21,7 @@ module Conekta
     end
 
     def last
-      self[self.count - 1]
+      self[self.keys.last]
     end
 
     def load_from(response)


### PR DESCRIPTION
Using `count -1` is not reliable as the payment sources returned by the API are filtered, but maintain their original index.

Also ensures that `@values` is initialised if it doesn't exist.

context:
```
we've discovered the issue is related to users who've added 6 or more payment sources.

I've submitted a PR for the new release that prevents the error: #78

That said, be aware that the API only returns 5 payment sources. In the raw response there is a has_more attribute and a link to the next_page_url, but the gem does not seem make use of it...
```