### PR TITLE
Allow capture amount to be set 

### DIFF
--- a/lib/conekta/charge.rb
+++ b/lib/conekta/charge.rb
@@ -11,8 +11,10 @@ module Conekta
                   :exchange_rate, :foreign_currency, :amount_in_foreign_currency,
                   :checkout_id, :checkout_order_count
 
-    def capture
-      custom_action(:post, 'capture')
+    # Usage: charge_reference.capture(2000)
+    def capture(params={})
+      params = { 'amount' => (params || self.amount) }
+      custom_action(:post, 'capture', params)
     end
 
     def refund(params=nil)

--- a/spec/conekta/1.0.0/charge_spec.rb
+++ b/spec/conekta/1.0.0/charge_spec.rb
@@ -133,4 +133,20 @@ describe Conekta::Charge do
       )
     end
   end
+
+  context 'capturing charges' do
+    it 'captures an existing charge' do
+      amount_before_capture = 2000
+      amount_after_capture  = 1000
+      capture = { capture: false }
+       transaction = Conekta::Charge.create(
+        payment_method.merge(card).merge(capture)
+      )
+      expect(transaction.status).to eq('pre_authorized')
+      expect(transaction.amount).to be == amount_before_capture 
+      transaction.capture(1000)
+      expect(transaction.amount).to be == amount_after_capture
+      expect(transaction.status).to eq("paid")
+    end
+  end
 end


### PR DESCRIPTION
**Why is this change neccesary?**
This change allow users capture amounts less than the full preauth amount of the order
**How does it address the issue?**
allowing pass parameters to `capture` method
issue:
https://github.com/conekta/issues/issues/2514