### PR TITLE
Renamed params to amount on capture method

### DIFF
--- a/lib/conekta/charge.rb
+++ b/lib/conekta/charge.rb
@@ -12,8 +12,8 @@ module Conekta
                   :checkout_id, :checkout_order_count
 
     # Usage: charge_reference.capture(2000)
-    def capture(params={})
-      params = { 'amount' => (params || self.amount) }
+    def capture(capture_amount=nil)
+      params = { 'amount' => (capture_amount || self.amount) }
       custom_action(:post, 'capture', params)
     end
 


### PR DESCRIPTION
# Renamed params to amount on capture method
## Why is this change necessary?
Although is not really necessary, we do this for good practices and to avoid unnecessary 
empty hash initialization.

## How do we address the issue?
* Renamed `params` for `capture_amount`
* Changed initialization `capture_amount={}` for `capture_amount=nil`

## What to expect from this?
All functionality is the same. Only cleaner code.

## Changes

```
  modified lib/conekta/charge.rb
```