### PR TITLE
Add support for oxxo recurrent. (#91)

### DIFF
--- a/lib/conekta/customer.rb
+++ b/lib/conekta/customer.rb
@@ -57,6 +57,10 @@ module Conekta
       self.create_member_with_relation('payment_sources', params, self)
     end
 
+    def create_offline_recurrent_reference(params)
+      self.create_member_with_relation('payment_sources', params, self)
+    end
+
     def create_subscription(params)
       self.create_member('subscription', params)
     end

--- a/lib/conekta/payment_source.rb
+++ b/lib/conekta/payment_source.rb
@@ -11,7 +11,7 @@ module Conekta
     end
 
     def delete
-      self.delete_member('customer','payment_sources')
+      self.delete_member('customer', 'payment_sources')
     end
   end
 end

--- a/spec/conekta/2.0.0/customer_spec.rb
+++ b/spec/conekta/2.0.0/customer_spec.rb
@@ -8,6 +8,24 @@ describe Conekta::Customer do
 
       let(:customer) { Conekta::Customer.create(customer_data) }
 
+      let(:customer_oxxo) {
+        {
+          payment_sources: [{
+            type: 'oxxo_recurrent',
+            expires_at: 157_559_040_0
+          }],
+          email: 'test@gmail.com',
+          name: 'Mario'
+        }
+      }
+
+      let(:oxxo_source_params) do
+        {
+          type: 'oxxo_recurrent',
+          expires_at: 157_559_040_0
+        }
+      end
+
       let(:source_params) do
         {
           type:     "card",
@@ -31,10 +49,20 @@ describe Conekta::Customer do
       end
 
       it "successfully creates source for customer" do
-        source = customer.create_payment_source(source_params)
+        customer = Conekta::Customer.create(customer_oxxo)
+        source = customer.payment_sources.first
+
+        expect(source.class.to_s).to eq('Conekta::PaymentSource')
+        expect(customer.payment_sources.class.to_s).to eq('Conekta::List')
+        expect(source.reference.size).to eq(14)
+      end
+
+      it 'successfully creates oxxo recurrent reference for customer' do
+        source = customer.create_offline_recurrent_reference(oxxo_source_params)
 
         expect(source.class.to_s).to eq("Conekta::PaymentSource")
         expect(customer.payment_sources.class.to_s).to eq("Conekta::List")
+        expect(source.reference.size).to eq(14)
       end
 
       it "successfully creates shipping contact for customer" do


### PR DESCRIPTION
Why is this change neccesary?

We need a way to create oxxo recurrent reference.

How does it address the issue?

Added a method create_oxxo_recurrent_reference method

What side effects does this change have?

Hope no one