### PR TITLE
Removing ConektaList.total logic in favor of has_more

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [2.5.0](https://github.com/conekta/conekta-ruby/releases/tag/2.5.0) - 2020-06-08
+### Deprecate List Total attribute
+- Remove total attribute logic for lists as it is deprecated and will be removed.
+  Going forward use the has_more attribute of lists to determine whether you
+  should keep paginating.
+
 ## [2.4.2](https://github.com/conekta/conekta-ruby/releases/tag/2.4.2) - 2020-01-22
 ### Ruby 2.7 Cleanup
 - Corrects warnings related to translate in Ruby 2.7

--- a/lib/conekta/list.rb
+++ b/lib/conekta/list.rb
@@ -42,7 +42,6 @@ module Conekta
 
     def load_from(response)
       @has_more       = response["has_more"]
-      @total          = response["total"]
       self.map{|key, _| self.unset_key(key) }
       super(response["data"])
     end

--- a/lib/conekta/version.rb
+++ b/lib/conekta/version.rb
@@ -1,3 +1,3 @@
 module Conekta
-  VERSION = '2.4.2'.freeze
+  VERSION = '2.5.0'.freeze
 end


### PR DESCRIPTION
The total attribute will be removed in the future for optimization reasons, so we are removing it from the library in anticipation.